### PR TITLE
Remove spaces around "=" in Docker output

### DIFF
--- a/JsonToEnvironmentConverter/Pages/Index.cshtml.cs
+++ b/JsonToEnvironmentConverter/Pages/Index.cshtml.cs
@@ -72,7 +72,7 @@ namespace JsonToEnvironmentConverter.Pages
                     }
                     else
                     {
-                        format = "{0} = {1}";
+                        format = "{0}={1}";
                     }
                     foreach ((string key, string value) in configurationRoot.AsEnumerable()
                         .Where(pair => IncludeEmpty || !string.IsNullOrEmpty(pair.Value))


### PR DESCRIPTION
This ensures that you can copy the output directly into a file and
use `docker run --env-file`

Otherwise you get something like:

```bash
$ docker run --env-file=env.development my/image
docker: poorly formatted environment: variable 'ConnectionStrings__Default ' contains whitespaces.
See 'docker run --help'.
```